### PR TITLE
Fix NA estimated for PK parameters

### DIFF
--- a/R/mod_results_ddi.R
+++ b/R/mod_results_ddi.R
@@ -205,51 +205,46 @@ mod_results_ddi_server <- function(id, r) {
       pk_data_ddi <- r$results$pk_results$`DDI Simulation`
       pk_data_single <- r$results$pk_results$`Single Simulation`
 
-      auc_ddi <- pk_data_ddi |>
-        dplyr::filter(Parameter == "AUC_tDLast_minus_1_tDLast") |>
-        dplyr::pull(r$inputs$victim) |>
-        unlist()
+      auc_ddi_result <- extract_pk_values(
+        pk_data_ddi, "AUC_tDLast_minus_1_tDLast", "AUC_tEnd", r$inputs$victim
+      )
+      auc_single_result <- extract_pk_values(
+        pk_data_single, "AUC_tDLast_minus_1_tDLast", "AUC_tEnd", r$inputs$victim
+      )
 
-      auc_single <- pk_data_single |>
-        dplyr::filter(Parameter == "AUC_tDLast_minus_1_tDLast") |>
-        dplyr::pull(r$inputs$victim) |>
-        unlist()
+      cmax_ddi_result <- extract_pk_values(
+        pk_data_ddi, "C_max_tDLast_tEnd", "C_max", r$inputs$victim
+      )
+      cmax_single_result <- extract_pk_values(
+        pk_data_single, "C_max_tDLast_tEnd", "C_max", r$inputs$victim
+      )
 
-      cmax_ddi <- pk_data_ddi |>
-        dplyr::filter(Parameter == "C_max_tDLast_tEnd") |>
-        dplyr::pull(r$inputs$victim) |>
-        unlist()
-
-      cmax_single <- pk_data_single |>
-        dplyr::filter(Parameter == "C_max_tDLast_tEnd") |>
-        dplyr::pull(r$inputs$victim) |>
-        unlist()
-
-      tmax_ddi <- pk_data_ddi |>
-        dplyr::filter(Parameter == "t_max_tDLast_tEnd") |>
-        dplyr::pull(r$inputs$victim) |>
-        unlist()
-
-      tmax_single <- pk_data_single |>
-        dplyr::filter(Parameter == "t_max_tDLast_tEnd") |>
-        dplyr::pull(r$inputs$victim) |>
-        unlist()
-
-      victim_molw <- r$results$sim_results$`DDI Simulation` |>
-        dplyr::filter(stringr::str_detect(paths, r$inputs$victim)) |>
-        dplyr::pull(molWeight) |>
-        unique()
+      tmax_ddi_result <- extract_pk_values(
+        pk_data_ddi, "t_max_tDLast_tEnd", "t_max", r$inputs$victim
+      )
+      tmax_single_result <- extract_pk_values(
+        pk_data_single, "t_max_tDLast_tEnd", "t_max", r$inputs$victim
+      )
 
       auc_ratio <- signif(
-        quantile(auc_ddi / auc_single, probs = c(0.05, .5, 0.95)),
+        quantile(
+          auc_ddi_result$values / auc_single_result$values,
+          probs = c(0.05, .5, 0.95), na.rm = TRUE
+        ),
         4
       )
       cmax_ratio <- signif(
-        quantile(cmax_ddi / cmax_single, probs = c(0.05, .5, 0.95)),
+        quantile(
+          cmax_ddi_result$values / cmax_single_result$values,
+          probs = c(0.05, .5, 0.95), na.rm = TRUE
+        ),
         4
       )
       tmax_ratio <- signif(
-        quantile(tmax_ddi / tmax_single, probs = c(0.05, .5, 0.95)),
+        quantile(
+          tmax_ddi_result$values / tmax_single_result$values,
+          probs = c(0.05, .5, 0.95), na.rm = TRUE
+        ),
         4
       )
 

--- a/R/mod_results_pk.R
+++ b/R/mod_results_pk.R
@@ -207,35 +207,42 @@ mod_results_pk_server <- function(id, r) {
 
       vb_data <- r$results$pk_results$`DDI Simulation`
 
-      victim_cmax <- vb_data |>
-        dplyr::filter(Parameter == "C_max_tDLast_tEnd") |>
-        dplyr::pull(r$inputs$victim) |>
-        unlist()
+      cmax_result <- extract_pk_values(
+        vb_data, "C_max_tDLast_tEnd", "C_max", r$inputs$victim
+      )
 
       victim_molw <- r$results$sim_results$`DDI Simulation` |>
         dplyr::filter(stringr::str_detect(paths, r$inputs$victim)) |>
         dplyr::pull(molWeight) |>
         unique()
 
-      victim_tmax <- vb_data |>
-        dplyr::filter(Parameter == "t_max_tDLast_tEnd") |>
-        dplyr::pull(r$inputs$victim) |>
-        unlist()
+      tmax_result <- extract_pk_values(
+        vb_data, "t_max_tDLast_tEnd", "t_max", r$inputs$victim
+      )
 
-      victim_auc <- vb_data |>
-        dplyr::filter(Parameter == "AUC_tDLast_minus_1_tDLast") |>
-        dplyr::pull(r$inputs$victim) |>
-        unlist()
+      auc_result <- extract_pk_values(
+        vb_data, "AUC_tDLast_minus_1_tDLast", "AUC_tEnd", r$inputs$victim
+      )
 
       victim_cmax <- signif(
-        quantile(victim_cmax * victim_molw, probs = c(0.05, .5, 0.95)),
+        quantile(cmax_result$values * victim_molw, probs = c(0.05, .5, 0.95)),
         4
       ) # µmol/L -> µg/L
-      victim_tmax <- signif(quantile(victim_tmax, probs = c(0.05, .5, 0.95)), 4) # hours
+      victim_tmax <- signif(
+        quantile(tmax_result$values, probs = c(0.05, .5, 0.95)),
+        4
+      ) # hours
       victim_auc <- signif(
-        quantile(victim_auc * victim_molw / 60, probs = c(0.05, .5, 0.95)),
+        quantile(auc_result$values * victim_molw / 60, probs = c(0.05, .5, 0.95)),
         4
       ) # µmol*min/L -> µg*h/L
+
+      # Dynamic tooltip based on which AUC parameter was used
+      if (auc_result$param_used == "AUC_tDLast_minus_1_tDLast") {
+        auc_tooltip_text <- "Area under the curve between the (last-1) and last application (AUC_tDlast-1_tDlast): The integral of the concentration-time curve during the last dosing interval, representing total drug exposure."
+      } else {
+        auc_tooltip_text <- "Area under the curve from start to end of simulation (AUC_tEnd): Total drug exposure over the entire simulation period. Shown because a single dose protocol has no last dosing interval."
+      }
 
       layout_column_wrap(
         1 / 3,
@@ -256,7 +263,7 @@ mod_results_pk_server <- function(id, r) {
         quantile_value_box(
           tooltip(
             "AUC (µg*h/L)",
-            "Area under the curve between the (last-1) and last application (AUC_tDlast-1_tDlast): The integral of the concentration-time curve during the last dosing interval, representing total drug exposure."
+            auc_tooltip_text
           ),
           victim_auc
         )
@@ -277,4 +284,30 @@ quantile_value_box <- function(title, quantiles, icon = NULL) {
     paste0("Median: ", quantiles[2]),
     paste0("[", quantiles[1], " - ", quantiles[3], "]")
   )
+}
+
+#' Extract PK parameter values with fallback for single-dose scenarios
+#'
+#' @param pk_data A tibble of PK analysis results (pivoted)
+#' @param param Primary parameter name to extract
+#' @param fallback_param Fallback parameter name if primary returns no valid data
+#' @param compound Column name for the compound to pull values from
+#' @return A list with `values` (numeric vector) and `param_used` (character)
+#' @noRd
+extract_pk_values <- function(pk_data, param, fallback_param, compound) {
+  vals <- pk_data |>
+    dplyr::filter(Parameter == param) |>
+    dplyr::pull(compound) |>
+    unlist()
+
+  if (length(vals) > 0 && !all(is.na(vals) | is.nan(vals))) {
+    return(list(values = vals, param_used = param))
+  }
+
+  vals <- pk_data |>
+    dplyr::filter(Parameter == fallback_param) |>
+    dplyr::pull(compound) |>
+    unlist()
+
+  return(list(values = vals, param_used = fallback_param))
 }


### PR DESCRIPTION
When a single dose is selected in the victim protocol, AUC_tDLast_minus_1_tDLast returns NaN (no second-to-last dose exists). Added extract_pk_values() helper that falls back to AUC_tEnd for AUC, C_max for
  Cmax, and t_max for Tmax. Updated both mod_results_pk.R and mod_results_ddi.R with dynamic tooltips and na.rm = TRUE guards on ratio quantiles.