### PR TITLE
add height and fill to plotly in card

### DIFF
--- a/R/mod_results_ddi.R
+++ b/R/mod_results_ddi.R
@@ -15,13 +15,14 @@ mod_results_ddi_ui <- function(id) {
     card(
       fill = TRUE,
       card_body(
+        fillable = TRUE,
         checkboxInput(
           ns("show_perpetrator"),
           "Show Perpetrator",
           FALSE,
           width = "auto"
         ),
-        plotlyOutput(ns("plot"))
+        plotlyOutput(ns("plot"), height = "100%")
       )
     )
   )

--- a/R/mod_results_pk.R
+++ b/R/mod_results_pk.R
@@ -18,13 +18,14 @@ mod_results_pk_ui <- function(id) {
       #   "Time Profile",
       # ),
       card_body(
+        fillable = TRUE,
         checkboxInput(
           ns("show_perpetrator"),
           "Show Perpetrator",
           FALSE,
           width = "auto"
         ),
-        plotlyOutput(ns("plot"))
+        plotlyOutput(ns("plot"), height = "100%")
       )
     )
   )


### PR DESCRIPTION
plotlyOutput() defaults to a fixed 400px height, which caused plots to shrink after re-rendering on a second simulation run. Added fillable = TRUE to card_body() and height = "100%" to plotlyOutput() in both PK and DDI result modules so plots consistently fill their containers on every render.

Will resolve #32 
